### PR TITLE
Switch story

### DIFF
--- a/.changeset/five-bikes-sell.md
+++ b/.changeset/five-bikes-sell.md
@@ -1,0 +1,5 @@
+---
+"@spear-ai/ui": minor
+---
+
+Added Switch story.

--- a/packages/ui/src/components/switch/switch.stories.tsx
+++ b/packages/ui/src/components/switch/switch.stories.tsx
@@ -1,0 +1,71 @@
+import { CheckIcon, MinusIcon } from "@radix-ui/react-icons";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Form, Switch } from "react-aria-components";
+import { useIntl } from "react-intl";
+
+const PreviewSwitch = (properties: {
+  hasLabelDescription: boolean;
+  isDisabled: boolean;
+  isInvalid: boolean;
+  isReadonly: boolean;
+  isSquished: boolean;
+}) => {
+  const { hasLabelDescription, isDisabled, isInvalid, isReadonly, isSquished } = properties;
+  const intl = useIntl();
+
+  return (
+    <div className={`w-full ${isSquished ? "max-w-36" : "max-w-xs"}`}>
+      <Form className="relative w-full">
+        <div className="mt-3">
+          <Switch
+            className="group peer flex"
+            isDisabled={isDisabled}
+            isInvalid={isInvalid}
+            isReadOnly={isReadonly}
+            value="isLimitedToFriends"
+          >
+            <div className="relative me-3 inline-flex size-4 items-center rounded border border-neutral-a-7 bg-white-a-3 text-neutral-12 group-invalid:border-x-negative-a-7 group-focus-visible:outline group-focus-visible:outline-2 group-focus-visible:outline-primary-7 group-selected:border-transparent group-selected:bg-primary-9 group-selected:text-primary-contrast group-invalid:group-selected:border-x-negative-a-7 group-disabled:border-neutral-a-6 group-disabled:bg-neutral-a-3 group-disabled:text-neutral-a-8 group-invalid:group-disabled:border-x-negative-a-6 theme-dfs:bg-canvas-1 theme-dfs:group-invalid:border-x-negative-a-7 theme-dfs:group-disabled:bg-neutral-a-3 theme-forerunner:group-selected:bg-black-a-12 theme-forerunner:group-selected:text-white theme-forerunner:group-disabled:border-neutral-a-6 theme-forerunner:group-disabled:bg-neutral-a-3 theme-forerunner:group-disabled:text-neutral-a-8 theme-forerunner:group-invalid:group-disabled:border-x-negative-a-6 theme-galapago:bg-white dark:bg-white-a-3 theme-dfs:dark:bg-white-a-3 theme-dfs:group-selected:dark:border-neutral-a-7 theme-dfs:group-invalid:group-selected:dark:border-x-negative-a-7 theme-forerunner:dark:bg-black-a-3 theme-forerunner:group-selected:dark:border-neutral-a-7 theme-forerunner:group-selected:dark:bg-primary-a-5 theme-forerunner:group-selected:dark:text-primary-12 theme-forerunner:group-invalid:group-selected:dark:border-x-negative-a-7 theme-forerunner:group-disabled:dark:border-neutral-a-6 theme-forerunner:group-disabled:dark:bg-neutral-a-3 theme-forerunner:group-disabled:dark:text-neutral-a-8 theme-forerunner:group-invalid:group-disabled:dark:border-x-negative-a-6 theme-galapago:dark:bg-black-a-3 theme-galapago:dark:group-selected:bg-primary-a-9 theme-galapago:group-disabled:dark:bg-neutral-a-3 theme-galapago:group-disabled:dark:text-neutral-a-8 theme-galapago:dark:disabled:bg-neutral-a-3">
+              <CheckIcon className="absolute -left-px -top-px size-4 opacity-0 group-indeterminate:!opacity-0 group-selected:opacity-100" />
+              <MinusIcon className="h-full opacity-0 group-indeterminate:group-selected:opacity-100" />
+            </div>
+            <span className="-mt-1 flex-1 text-sm font-medium leading-6 text-neutral-12 group-invalid:text-x-negative-11 group-disabled:text-neutral-11 group-invalid:group-disabled:text-x-negative-9">
+              {intl.formatMessage({
+                defaultMessage: "Show only to friends",
+                id: "709cRj",
+              })}
+            </span>
+          </Switch>
+          {hasLabelDescription ? (
+            <p className="ms-7 text-sm leading-6 text-neutral-11 peer-disabled:text-neutral-9">
+              {intl.formatMessage({
+                defaultMessage: "Whether only friends can see this post.",
+                id: "WuPCNC",
+              })}
+            </p>
+          ) : null}
+        </div>
+      </Form>
+    </div>
+  );
+};
+
+const meta = {
+  component: PreviewSwitch,
+} satisfies Meta<typeof PreviewSwitch>;
+
+type Story = StoryObj<typeof meta>;
+
+export const Standard: Story = {
+  args: {
+    hasLabelDescription: true,
+    isDisabled: false,
+    isInvalid: false,
+    isReadonly: false,
+    isSquished: false,
+  },
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;

--- a/packages/ui/src/components/switch/switch.stories.tsx
+++ b/packages/ui/src/components/switch/switch.stories.tsx
@@ -30,8 +30,8 @@ const PreviewSwitch = (properties: {
             {hasLabel ? (
               <span className="ms-3 flex-1 text-sm font-medium leading-6 text-neutral-12 group-disabled:text-neutral-11">
                 {intl.formatMessage({
-                  defaultMessage: "Enabled",
-                  id: "V52jNn",
+                  defaultMessage: "Receive notifications",
+                  id: "D6jkwD",
                 })}
               </span>
             ) : null}

--- a/packages/ui/src/components/switch/switch.stories.tsx
+++ b/packages/ui/src/components/switch/switch.stories.tsx
@@ -1,48 +1,38 @@
-import { CheckIcon, MinusIcon } from "@radix-ui/react-icons";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Form, Switch } from "react-aria-components";
 import { useIntl } from "react-intl";
 
 const PreviewSwitch = (properties: {
-  hasLabelDescription: boolean;
   isDisabled: boolean;
-  isInvalid: boolean;
+  isPrimary: boolean;
   isReadonly: boolean;
   isSquished: boolean;
 }) => {
-  const { hasLabelDescription, isDisabled, isInvalid, isReadonly, isSquished } = properties;
+  const { isDisabled, isPrimary, isReadonly, isSquished } = properties;
   const intl = useIntl();
 
   return (
-    <div className={`w-full ${isSquished ? "max-w-36" : "max-w-xs"}`}>
+    <div className={`w-full ${isSquished ? "max-w-36" : "max-w-sm"}`}>
       <Form className="relative w-full">
         <div className="mt-3">
           <Switch
-            className="group peer flex"
+            className="group flex"
             isDisabled={isDisabled}
-            isInvalid={isInvalid}
             isReadOnly={isReadonly}
             value="isLimitedToFriends"
           >
-            <div className="relative me-3 inline-flex size-4 items-center rounded border border-neutral-a-7 bg-white-a-3 text-neutral-12 group-invalid:border-x-negative-a-7 group-focus-visible:outline group-focus-visible:outline-2 group-focus-visible:outline-primary-7 group-selected:border-transparent group-selected:bg-primary-9 group-selected:text-primary-contrast group-invalid:group-selected:border-x-negative-a-7 group-disabled:border-neutral-a-6 group-disabled:bg-neutral-a-3 group-disabled:text-neutral-a-8 group-invalid:group-disabled:border-x-negative-a-6 theme-dfs:bg-canvas-1 theme-dfs:group-invalid:border-x-negative-a-7 theme-dfs:group-disabled:bg-neutral-a-3 theme-forerunner:group-selected:bg-black-a-12 theme-forerunner:group-selected:text-white theme-forerunner:group-disabled:border-neutral-a-6 theme-forerunner:group-disabled:bg-neutral-a-3 theme-forerunner:group-disabled:text-neutral-a-8 theme-forerunner:group-invalid:group-disabled:border-x-negative-a-6 theme-galapago:bg-white dark:bg-white-a-3 theme-dfs:dark:bg-white-a-3 theme-dfs:group-selected:dark:border-neutral-a-7 theme-dfs:group-invalid:group-selected:dark:border-x-negative-a-7 theme-forerunner:dark:bg-black-a-3 theme-forerunner:group-selected:dark:border-neutral-a-7 theme-forerunner:group-selected:dark:bg-primary-a-5 theme-forerunner:group-selected:dark:text-primary-12 theme-forerunner:group-invalid:group-selected:dark:border-x-negative-a-7 theme-forerunner:group-disabled:dark:border-neutral-a-6 theme-forerunner:group-disabled:dark:bg-neutral-a-3 theme-forerunner:group-disabled:dark:text-neutral-a-8 theme-forerunner:group-invalid:group-disabled:dark:border-x-negative-a-6 theme-galapago:dark:bg-black-a-3 theme-galapago:dark:group-selected:bg-primary-a-9 theme-galapago:group-disabled:dark:bg-neutral-a-3 theme-galapago:group-disabled:dark:text-neutral-a-8 theme-galapago:dark:disabled:bg-neutral-a-3">
-              <CheckIcon className="absolute -left-px -top-px size-4 opacity-0 group-indeterminate:!opacity-0 group-selected:opacity-100" />
-              <MinusIcon className="h-full opacity-0 group-indeterminate:group-selected:opacity-100" />
-            </div>
-            <span className="-mt-1 flex-1 text-sm font-medium leading-6 text-neutral-12 group-invalid:text-x-negative-11 group-disabled:text-neutral-11 group-invalid:group-disabled:text-x-negative-9">
+            <span
+              className={`group relative isolate inline-flex h-6 w-11 rounded-full border-2 border-transparent bg-neutral-a-3 transition duration-200 ease-in-out group-focus-visible:outline group-focus-visible:outline-2 group-focus-visible:outline-primary-7 group-disabled:bg-neutral-a-3 ${isPrimary ? "group-selected:bg-primary-9" : "group-selected:bg-neutral-9"}`}
+            >
+              <span className="pointer-events-none relative inline-block size-5 rounded-full bg-white shadow transition-all duration-200 ease-in-out will-change-transform translate-x-0 group-selected:translate-x-5 group-disabled:bg-neutral-2 group-disabled:shadow-none" />
+            </span>
+            <span className="ms-3 flex-1 text-sm font-medium leading-6 text-neutral-12 group-disabled:text-neutral-11">
               {intl.formatMessage({
-                defaultMessage: "Show only to friends",
-                id: "709cRj",
+                defaultMessage: "Enabled",
+                id: "V52jNn",
               })}
             </span>
           </Switch>
-          {hasLabelDescription ? (
-            <p className="ms-7 text-sm leading-6 text-neutral-11 peer-disabled:text-neutral-9">
-              {intl.formatMessage({
-                defaultMessage: "Whether only friends can see this post.",
-                id: "WuPCNC",
-              })}
-            </p>
-          ) : null}
         </div>
       </Form>
     </div>
@@ -57,9 +47,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Standard: Story = {
   args: {
-    hasLabelDescription: true,
     isDisabled: false,
-    isInvalid: false,
+    isPrimary: false,
     isReadonly: false,
     isSquished: false,
   },

--- a/packages/ui/src/components/switch/switch.stories.tsx
+++ b/packages/ui/src/components/switch/switch.stories.tsx
@@ -3,12 +3,13 @@ import { Form, Switch } from "react-aria-components";
 import { useIntl } from "react-intl";
 
 const PreviewSwitch = (properties: {
+  hasLabel: boolean;
   isDisabled: boolean;
   isPrimary: boolean;
   isReadonly: boolean;
   isSquished: boolean;
 }) => {
-  const { isDisabled, isPrimary, isReadonly, isSquished } = properties;
+  const { hasLabel, isDisabled, isPrimary, isReadonly, isSquished } = properties;
   const intl = useIntl();
 
   return (
@@ -26,12 +27,14 @@ const PreviewSwitch = (properties: {
             >
               <span className="pointer-events-none relative inline-block size-5 rounded-full bg-white shadow transition-all duration-200 ease-in-out will-change-transform translate-x-0 group-selected:translate-x-5 group-disabled:bg-neutral-2 group-disabled:shadow-none" />
             </span>
-            <span className="ms-3 flex-1 text-sm font-medium leading-6 text-neutral-12 group-disabled:text-neutral-11">
-              {intl.formatMessage({
-                defaultMessage: "Enabled",
-                id: "V52jNn",
-              })}
-            </span>
+            {hasLabel ? (
+              <span className="ms-3 flex-1 text-sm font-medium leading-6 text-neutral-12 group-disabled:text-neutral-11">
+                {intl.formatMessage({
+                  defaultMessage: "Enabled",
+                  id: "V52jNn",
+                })}
+              </span>
+            ) : null}
           </Switch>
         </div>
       </Form>
@@ -47,6 +50,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Standard: Story = {
   args: {
+    hasLabel: true,
     isDisabled: false,
     isPrimary: false,
     isReadonly: false,


### PR DESCRIPTION
@ThomasSeaver here's a first stab at a Switch component. There were a lot of judgement calls that needed to be made to reconcile differences between Catalyst UI, Tailwind UI proper and Tailwind UI templates. Tailwind UI does not consistently follow a standard for outline colors or height and widths. I ended up treating their [Toggles](https://tailwindui.com/components/application-ui/forms/toggles) page as the canonical version. They don't cover disabled states so I drew inspiration from Radix Playground for that. Catalyst UI uses a border; which, looks kind of nice but complicates the CSS. They also automatically render a larger switch in mobile and a smaller switch in tablet+. That seemed like too much magic to add right now.

This also assumes that a label is right justified and doesn't show what to do if there's a label description. But there are cases when one wants both a label description and wants those labels/descriptions to be left justified. I leave the work of showing that for later, perhaps when we create a component out of this.

Resolves #146 