### PR TITLE
Fix Tailwind content in code chunks

### DIFF
--- a/.changeset/beige-ads-notice.md
+++ b/.changeset/beige-ads-notice.md
@@ -1,0 +1,5 @@
+---
+"@spear-ai/ui": patch
+---
+
+Fixed Tailwind content not detecting CSS classes inside code chunks.

--- a/packages/ui/src/tailwind.ts
+++ b/packages/ui/src/tailwind.ts
@@ -1,3 +1,6 @@
 /* eslint-disable unicorn/prefer-module */
 
-export const tailwindContent = [`${__dirname}/components/**/*.js`, `${__dirname}/styles/**/*.css`];
+export const tailwindContent = [
+  `${__dirname}/../src/components/**/*.tsx`,
+  `${__dirname}/../src/styles/**/*.css`,
+];


### PR DESCRIPTION
Fixed Tailwind content not detecting CSS classes inside code chunks. This uses the `/src` directory instead because it's included in the distribution and should be quicker to parse.