### PR TITLE
Fix Storybook Dialog component’s width and padding

### DIFF
--- a/.changeset/heavy-onions-wave.md
+++ b/.changeset/heavy-onions-wave.md
@@ -1,0 +1,5 @@
+---
+"@spear-ai/storybook": patch
+---
+
+Fixed Storybook Dialog component’s width and padding with narrow content and/or on mobile devices.

--- a/packages/storybook/src/components/dialog/index.stories.tsx
+++ b/packages/storybook/src/components/dialog/index.stories.tsx
@@ -32,11 +32,8 @@ const PreviewDialog = (properties: {
         })}
       </Button>
       <DialogModalOverlay UNSTABLE_portalContainer={portalContainer} isDismissable={isDismissable}>
-        <DialogModal>
-          <Dialog
-            className="px-4 pb-4 pt-5 sm:w-full sm:max-w-sm sm:p-6"
-            role={isAlert ? "alertdialog" : undefined}
-          >
+        <DialogModal className="w-full sm:max-w-sm">
+          <Dialog className="px-4 pb-4 pt-5 sm:p-6" role={isAlert ? "alertdialog" : undefined}>
             {hasCloseButton ? (
               <DialogCloseIconButton>
                 <DialogCloseIconButtonIcon />


### PR DESCRIPTION
The Dialog's width was on the wrong container. Moreover, the width on mobile was missing.